### PR TITLE
quickfix: make plugin work with eclipse 2024-06 (4.32.0)

### DIFF
--- a/qwickie.feature/feature.xml
+++ b/qwickie.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="qwickie"
       label="qwickie"
-      version="1.2.0.qualifier"
+      version="1.2.1"
       provider-name="count.negative">
 
    <description url="https://raw.githubusercontent.com/count-negative/qwickie/master/qwickie.updatesite/site.xml">

--- a/qwickie.plugin/META-INF/MANIFEST.MF
+++ b/qwickie.plugin/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Automatic-Module-Name: qwickie.plugin
 Bundle-Name: qwickie
 Bundle-SymbolicName: qwickie.plugin;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.1
 Bundle-Activator: qwickie.QWickieActivator
 Bundle-Vendor: count.negative
 Require-Bundle: org.eclipse.ui,
@@ -21,5 +21,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.wst.html.ui,
  org.junit
 Bundle-ActivationPolicy: lazy
-Import-Package: org.eclipse.ui.texteditor
+Import-Package: org.eclipse.jdt.internal.corext.refactoring.rename,
+ org.eclipse.ui.texteditor
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/qwickie.plugin/src/qwickie/hyperlink/WicketHyperlink.java
+++ b/qwickie.plugin/src/qwickie/hyperlink/WicketHyperlink.java
@@ -272,7 +272,7 @@ public class WicketHyperlink implements IHyperlink {
 		} else { // if not, search for one with the same name
 			final FileSearcher fs = new FileSearcher(project, new Path(filename).lastSegment());
 			try {
-				final IJavaProject javaProject = (IJavaProject) project.getNature(JavaCore.NATURE_ID);
+				final IJavaProject javaProject = JavaCore.create(project);
 				final IPackageFragmentRoot[] packageFragmentRoots = javaProject.getPackageFragmentRoots();
 				project.accept(fs);
 				for (final IFile foundFile : fs.getFoundFiles()) {

--- a/qwickie.plugin/src/qwickie/util/FileSearcher.java
+++ b/qwickie.plugin/src/qwickie/util/FileSearcher.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectNature;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceVisitor;
 import org.eclipse.core.runtime.Assert;
@@ -101,7 +102,7 @@ public class FileSearcher implements IResourceVisitor {
 		final List<IPath> srcFolders = new ArrayList<IPath>();
 		IJavaProject javaProject;
 		try {
-			javaProject = (IJavaProject) project.getNature(JavaCore.NATURE_ID);
+			javaProject = JavaCore.create(project);
 			final IPackageFragmentRoot[] packageFragmentRoots = javaProject.getPackageFragmentRoots();
 			for (final IPackageFragmentRoot pfr : packageFragmentRoots) {
 				if (pfr.getKind() == IPackageFragmentRoot.K_SOURCE) {
@@ -157,8 +158,8 @@ public class FileSearcher implements IResourceVisitor {
 
 		IJavaProject javaProject = null;
 		try {
-			javaProject = (IJavaProject) project.getNature(JavaCore.NATURE_ID);
-		} catch (final CoreException e) {
+			javaProject = JavaCore.create(project);
+		} catch (final Exception e) {
 			// When it's not a java project, return false
 			return false;
 		}


### PR DESCRIPTION
Possibly also with 2024-03 (4.31.0).

This is a naive quickfix that may not be the right one, however it seems to work for me.